### PR TITLE
Excluded the ``tests`` folder from MPIRE distributions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Excluded the ``tests`` folder from MPIRE distributions (`#89`_)
+
+.. _#89: https://github.com/sybrenjansen/mpire/issues/89
+
+
 2.8.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
         long_description=read_description(),
         url='https://github.com/sybrenjansen/mpire',
         license='MIT',
-        packages=find_packages(),
+        packages=find_packages(exclude=['*tests*']),
         scripts=['bin/mpire-dashboard'],
         install_requires=['dataclasses; python_version<"3.7"',
                           'pywin32==225; platform_system=="Windows" and python_version=="3.6"',


### PR DESCRIPTION
Fixes #89 