### PR TITLE
Add newest python version remove EOL python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,9 +6,11 @@ Unreleased
 
 * Excluded the ``tests`` folder from MPIRE distributions (`#89`_)
 * Added a workaround for semaphore leakage on macOS and fixed a bug when working in a fork context while the system default is spawn (`#92`_)
+* Add testing python 3.12 to workflow and drop 3.6 and 3.7 (`#102`_)
 
 .. _#89: https://github.com/sybrenjansen/mpire/issues/89
 .. _#92: https://github.com/sybrenjansen/mpire/issues/92
+.. _#102: https://github.com/sybrenjansen/mpire/pull/102
 
 
 2.8.0

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,11 @@ if __name__ == '__main__':
             'Development Status :: 5 - Production/Stable',
 
             # Supported Python versions
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
 
             # License
             'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Python 3.6 and 3.7 have been end of life for a while, and a python 3.12 just came out earlier this month.