### PR TITLE
Apply-async timeouts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,11 +5,15 @@ Unreleased
 ----------
 
 * Excluded the ``tests`` folder from MPIRE distributions (`#89`_)
-* Added a workaround for semaphore leakage on macOS and fixed a bug when working in a fork context while the system default is spawn (`#92`_)
+* Added a workaround for semaphore leakage on macOS and fixed a bug when working in a fork context while the system
+  default is spawn (`#92`_)
 * Fix progressbar percentage on dashboard (`#101`_)
+* Fixed a bug where starting multiple `apply_async` tasks with a task timeout didn't interrupt all tasks when the
+  timeout was reached (`#98`_)
 
 .. _#89: https://github.com/sybrenjansen/mpire/issues/89
 .. _#92: https://github.com/sybrenjansen/mpire/issues/92
+.. _#98: https://github.com/sybrenjansen/mpire/issues/98
 .. _#101: https://github.com/sybrenjansen/mpire/pull/101
 
 

--- a/docs/usage/apply.rst
+++ b/docs/usage/apply.rst
@@ -155,4 +155,9 @@ Timeouts
 
 The ``apply`` family of functions also has ``task_timeout``, ``worker_init_timeout`` and ``worker_exit_timeout``
 arguments. These are timeouts for the task, the ``worker_init`` function and the ``worker_exit`` function, respectively.
-They work completely the same as for the ``map`` functions. See :ref:`timeouts` for more information.
+They work similarly as those for the ``map`` functions.
+
+When a single task times out, only that task is cancelled. The other tasks will continue to run. When a worker init or
+exit times out, the entire pool is stopped.
+
+See :ref:`timeouts` for more information.

--- a/mpire/exception.py
+++ b/mpire/exception.py
@@ -9,7 +9,12 @@ ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
 
 class StopWorker(Exception):
-    """ Exception used to kill workers from the main process """
+    """ Exception used to kill a worker """
+    pass
+
+
+class InterruptWorker(Exception):
+    """ Exception used to interrupt a worker """
     pass
 
 


### PR DESCRIPTION
Fixed a bug where starting multiple `apply_async` tasks with a task timeout didn't interrupt all tasks when the timeout was reached. Fixes #98