### PR TITLE
TQDM util updates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Unreleased
 
 * Add the option to only show progress on the dashboard. (`#107`_)
 * Import escape directly from markupsafe, instead of from flask. (`#106`_)
+* Progress bars are now supported on Windows.
 
 .. _#108: https://github.com/sybrenjansen/mpire/pull/107
 .. _#107: https://github.com/sybrenjansen/mpire/issues/106

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -152,7 +152,6 @@ Windows
 Windows support has some caveats:
 
 * When using worker insights the arguments of the top 5 longest tasks are not available;
-* Progress bar is not supported when using threading as start method;
 * When using ``dill`` and an exception occurs, or when the exception occurs in an exit function, it can print additional
   ``OSError`` messages in the terminal, but they can be safely ignored.
 

--- a/mpire/params.py
+++ b/mpire/params.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from unittest.mock import patch
 from tqdm import tqdm, TqdmKeyError
 
-from mpire.context import DEFAULT_START_METHOD, RUNNING_WINDOWS
+from mpire.context import DEFAULT_START_METHOD
 from mpire.tqdm_utils import get_tqdm
 
 # Typedefs
@@ -206,11 +206,6 @@ def check_map_parameters(pool_params: WorkerPoolParams, iterable_of_args: Union[
 
     # If worker lifespan is not None or not a positive integer, raise
     check_number(worker_lifespan, 'worker_lifespan', allowed_types=(int,), none_allowed=True, min_=1)
-
-    # Progress bar is currently not supported on Windows when using threading as start method. For reasons still
-    # unknown we get a TypeError: cannot pickle '_thread.Lock' object.
-    if RUNNING_WINDOWS and progress_bar and pool_params.start_method == "threading":
-        raise ValueError("Progress bar is currently not supported on Windows when using start_method='threading'")
 
     # Check progress bar parameters and set default values
     progress_bar_options = check_progress_bar_options(progress_bar_options, progress_bar_position, n_tasks,

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -278,8 +278,6 @@ class CheckMapParametersTest(unittest.TestCase):
         """
         Should raise when wrong parameter values are used
         """
-        pool_params = WorkerPoolParams(None, None)
-
         # Get number of tasks
         with self.subTest('get n_tasks', iterable_of_args=range(100)):
             n_tasks, *_ = self.check_map_parameters_func(iterable_of_args=range(100), iterable_len=None)
@@ -372,14 +370,6 @@ class CheckMapParametersTest(unittest.TestCase):
             args, kwargs = worker_lifespan_call[0], worker_lifespan_call[1]
             self.assertEqual(args[0], 11)
             self.assertDictEqual(kwargs, {"allowed_types": (int,), "none_allowed": True, "min_": 1})
-
-    def test_windows_threading_progress_bar_error(self):
-        """
-        Check that when a progress bar is requested on windows when threading is used, a ValueError is raised.
-        """
-        with patch('mpire.params.RUNNING_WINDOWS', side_effect=True), self.assertRaises(ValueError):
-            pool_params = WorkerPoolParams(2, None, start_method='threading')
-            self.check_map_parameters_func(pool_params=pool_params, progress_bar=True)
 
     def test_timeout(self):
         """

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1068,16 +1068,10 @@ class ProgressBarTest(unittest.TestCase):
         """
         print()
         for start_method in TEST_START_METHODS:
-            with self.subTest(start_method=start_method), \
-                    WorkerPool(n_jobs=2, start_method=start_method) as pool:
-                # Progress bar on Windows with threading is currently not supported
-                if RUNNING_WINDOWS and start_method == 'threading':
-                    with self.assertRaises(ValueError):
-                        pool.map(square, self.test_data, progress_bar=True)
-                else:
-                    results_list = pool.map(square, self.test_data, progress_bar=True)
-                    self.assertIsInstance(results_list, list)
-                    self.assertEqual(self.test_desired_output, results_list)
+            with self.subTest(start_method=start_method), WorkerPool(n_jobs=2, start_method=start_method) as pool:
+                results_list = pool.map(square, self.test_data, progress_bar=True)
+                self.assertIsInstance(results_list, list)
+                self.assertEqual(self.test_desired_output, results_list)
 
 
 class KeepAliveTest(unittest.TestCase):


### PR DESCRIPTION
- TQDM connection details updated. There was no need to put them into process aware objects
- Progress bar didn't need connection details to be serialized, as a thread simply uses the same memory pool.
- Progress bar also works on Windows now.