### PR TITLE
Fixed an authentication error when using a progress bar or insights in a spawn or forkserver context when using dill

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Unreleased
 * Fixed a bug in the timeout handler where the cache dictionary could be changed during iteration (`#123`_)
 * Fixed an authentication error when using a progress bar or insights in a spawn or forkserver context when using dill 
   (`#124`_)
-
+ 
 .. _#123: https://github.com/sybrenjansen/mpire/issues/123
 .. _#124: https://github.com/sybrenjansen/mpire/issues/124
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Unreleased
 * Fixed a bug in the timeout handler where the cache dictionary could be changed during iteration (`#123`_)
 * Fixed an authentication error when using a progress bar or insights in a spawn or forkserver context when using dill 
   (`#124`_)
- 
+
 .. _#123: https://github.com/sybrenjansen/mpire/issues/123
 .. _#124: https://github.com/sybrenjansen/mpire/issues/124
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fixed an authentication error when using a progress bar or insights in a spawn or forkserver context when using dill 
+  (`#124`_)
+
+.. _#124: https://github.com/sybrenjansen/mpire/issues/124
+
+
 2.10.0
 ------
 

--- a/mpire/context.py
+++ b/mpire/context.py
@@ -1,6 +1,7 @@
 import multiprocessing as mp
 try:
     import multiprocess as mp_dill
+    import multiprocess.managers  # Needed in utils.py
 except ImportError:
     mp_dill = None
 import platform

--- a/mpire/dashboard/manager.py
+++ b/mpire/dashboard/manager.py
@@ -1,4 +1,5 @@
 from multiprocessing import Lock
+from multiprocessing.synchronize import Lock as LockType
 from multiprocessing.managers import BaseProxy
 from typing import Dict, Optional, Tuple
 
@@ -39,7 +40,7 @@ def get_dashboard_tqdm_details_dict() -> Dict:
     return DASHBOARD_TQDM_DETAILS_DICT
 
 
-def get_dashboard_tqdm_lock() -> Lock:
+def get_dashboard_tqdm_lock() -> LockType:
     """
     :return: Dashboard tqdm lock which should be used in a DashboardManager context
     """

--- a/mpire/insights.py
+++ b/mpire/insights.py
@@ -15,15 +15,17 @@ class WorkerInsights:
     exit functions are provided it will time those as well.
     """
 
-    def __init__(self, ctx: multiprocessing.context.BaseContext, n_jobs: int) -> None:
+    def __init__(self, ctx: multiprocessing.context.BaseContext, n_jobs: int, use_dill: bool) -> None:
         """
         Parameter class for worker insights.
 
         :param ctx: Multiprocessing context
         :param n_jobs: Number of workers
+        :param use_dill: Whether dill is used as serialization library
         """
         self.ctx = ctx
         self.n_jobs = n_jobs
+        self.use_dill = use_dill
 
         # Whether insights have been enabled or not
         self.insights_enabled = False
@@ -66,7 +68,7 @@ class WorkerInsights:
             # We need to use a special wrapper which sets the manager to None when pickled. For some reason Python 
             # won't use the __getstate__/__setstate__ of this class when passing the object to a worker, so we move
             # the logic to the wrapper instead.
-            self.insights_manager = NonPickledSyncManager()
+            self.insights_manager = NonPickledSyncManager(self.use_dill)
             self.insights_manager.start()
             self.insights_manager_lock = self.ctx.Lock()
             self.worker_start_up_time = self.ctx.Array(ctypes.c_double, self.n_jobs, lock=False)

--- a/mpire/pool.py
+++ b/mpire/pool.py
@@ -114,7 +114,7 @@ class WorkerPool:
         self._progress_bar_handler = None
 
         # Worker insights, used for profiling
-        self._worker_insights = WorkerInsights(self.ctx, self.pool_params.n_jobs)
+        self._worker_insights = WorkerInsights(self.ctx, self.pool_params.n_jobs, self.pool_params.use_dill)
 
     def pass_on_worker_id(self, pass_on: bool = True) -> None:
         """
@@ -718,7 +718,7 @@ class WorkerPool:
             # Start tqdm manager if a progress bar is desired. Will only start one when not already started. This has to
             # be done before starting the workers in case nested pools are used
             if progress_bar:
-                tqdm_manager_owner = TqdmManager.start_manager()
+                tqdm_manager_owner = TqdmManager.start_manager(self.pool_params.use_dill)
 
             # Start workers if there aren't any. If they already exist check if we need to pass on new parameters
             if self._workers and not self._worker_comms.is_initialized():

--- a/mpire/tqdm_utils.py
+++ b/mpire/tqdm_utils.py
@@ -6,7 +6,6 @@ from multiprocessing import Lock as mp_Lock
 from multiprocessing.synchronize import Lock as LockType
 from typing import Optional, Tuple, Type
 
-from multiprocess import Lock as mp_dill_Lock
 from tqdm import TqdmExperimentalWarning, tqdm as tqdm_std
 from tqdm.notebook import tqdm as tqdm_notebook
 try:
@@ -16,6 +15,7 @@ except ImportError:
     tqdm_rich = None
     RICH_AVAILABLE = False
 
+from mpire.context import mp_dill
 from mpire.signal import DisableKeyboardInterruptSignal
 from mpire.utils import create_sync_manager
 
@@ -226,7 +226,7 @@ class TqdmPositionRegister:
         """
         :param use_dill: Whether dill is used as serialization library
         """
-        self.lock = mp_dill_Lock() if use_dill else mp_Lock()
+        self.lock = mp_dill.Lock() if use_dill else mp_Lock()
         self.highest_position = None
 
     def register_progress_bar_position(self, position: int) -> bool:

--- a/mpire/tqdm_utils.py
+++ b/mpire/tqdm_utils.py
@@ -1,12 +1,12 @@
 import logging
-import os
 import warnings
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
-from multiprocessing import Lock
-from multiprocessing.managers import SyncManager
-from typing import Optional, Tuple, Type, Union
+from multiprocessing import Lock as mp_Lock
+from multiprocessing.synchronize import Lock as LockType
+from typing import Optional, Tuple, Type
 
+from multiprocess import Lock as mp_dill_Lock
 from tqdm import TqdmExperimentalWarning, tqdm as tqdm_std
 from tqdm.notebook import tqdm as tqdm_notebook
 try:
@@ -17,9 +17,10 @@ except ImportError:
     RICH_AVAILABLE = False
 
 from mpire.signal import DisableKeyboardInterruptSignal
+from mpire.utils import create_sync_manager
 
 PROGRESS_BAR_DEFAULT_STYLE = 'std'
-TqdmConnectionDetails = Tuple[Lock, "TqdmPositionRegister"]
+TqdmConnectionDetails = Tuple[LockType, "TqdmPositionRegister"]
 
 logger = logging.getLogger(__name__)
 
@@ -221,11 +222,14 @@ class TqdmPositionRegister:
     progress bars
     """
 
-    def __init__(self) -> None:
-        self.lock = Lock()
+    def __init__(self, use_dill: bool) -> None:
+        """
+        :param use_dill: Whether dill is used as serialization library
+        """
+        self.lock = mp_dill_Lock() if use_dill else mp_Lock()
         self.highest_position = None
 
-    def register_progress_bar_position(self, position) -> bool:
+    def register_progress_bar_position(self, position: int) -> bool:
         """
         Register new progress bar position. Returns True when it's the first one to register
 
@@ -265,10 +269,11 @@ class TqdmManager:
     POSITION_REGISTER = None
 
     @classmethod
-    def start_manager(cls) -> bool:
+    def start_manager(cls, use_dill: bool) -> bool:
         """
         Sets up and starts the tqdm manager
 
+        :param use_dill: Whether dill is used as serialization library
         :return: Whether the manager was started
         """
         # Don't do anything when there's already a tqdm manager that has started
@@ -279,11 +284,11 @@ class TqdmManager:
 
         # Create manager
         with DisableKeyboardInterruptSignal():
-            cls.MANAGER = SyncManager(authkey=os.urandom(24))
+            cls.MANAGER = create_sync_manager(use_dill)
             cls.MANAGER.register('TqdmPositionRegister', TqdmPositionRegister)
             cls.MANAGER.start()
             cls.LOCK = cls.MANAGER.Lock()
-            cls.POSITION_REGISTER = cls.MANAGER.TqdmPositionRegister()
+            cls.POSITION_REGISTER = cls.MANAGER.TqdmPositionRegister(use_dill)
 
         return True
 

--- a/mpire/utils.py
+++ b/mpire/utils.py
@@ -5,11 +5,10 @@ import os
 import time
 from datetime import timedelta
 from multiprocessing import cpu_count
-from multiprocessing.managers import SyncManager as mp_SyncManager
+from multiprocessing.managers import SyncManager
 from multiprocessing.sharedctypes import SynchronizedArray
 from typing import Callable, Collection, Generator, Iterable, List, Optional, Tuple, Union
 
-from multiprocess.managers import SyncManager as mp_dill_SyncManager
 try:
     import numpy as np
     NUMPY_INSTALLED = True
@@ -17,7 +16,7 @@ except ImportError:
     np = None
     NUMPY_INSTALLED = False
 
-from mpire.context import RUNNING_MACOS, RUNNING_WINDOWS
+from mpire.context import RUNNING_MACOS, RUNNING_WINDOWS, mp_dill
 
 # Needed for setting CPU affinity
 if RUNNING_WINDOWS:
@@ -251,7 +250,7 @@ class TimeIt:
                               (duration, self.format_args_func() if self.format_args_func is not None else None))
 
 
-def create_sync_manager(use_dill: bool) -> Union[mp_SyncManager, mp_dill_SyncManager]:
+def create_sync_manager(use_dill: bool) -> SyncManager:
     """
     Create a SyncManager instance
 
@@ -259,7 +258,7 @@ def create_sync_manager(use_dill: bool) -> Union[mp_SyncManager, mp_dill_SyncMan
     :return: SyncManager instance
     """
     authkey = os.urandom(24)
-    return mp_dill_SyncManager(authkey=authkey) if use_dill else mp_SyncManager(authkey=authkey)
+    return mp_dill.managers.SyncManager(authkey=authkey) if use_dill else SyncManager(authkey=authkey)
 
     
 class NonPickledSyncManager:


### PR DESCRIPTION
Fixes #124 

The fix simply means I had to use the `multiprocess.managers.SyncManager` when using dill instead of the `multiprocessing` one.