### PR TITLE
128 mpire crashes when obtaining function details

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Function details in ``progress_bar.py`` are only obtained when the dashboard is running (`#128`_)
+* Obtaining the user name is now put in a try-except block to prevent MPIRE from crashing when the user name cannot be
+  obtained. which can happen when running in a container as a non-root user (`#128`_)
+
+.. _#128: https://github.com/sybrenjansen/mpire/issues/128
+
+
 2.10.1
 ------
 

--- a/mpire/dashboard/connection_classes.py
+++ b/mpire/dashboard/connection_classes.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
 from multiprocessing import Event
 from multiprocessing.managers import BaseManager
-from typing import Any, Optional
+from multiprocessing.synchronize import Event as EventType
+from typing import Optional
 
 
 class DashboardStartedEvent:
     
     def __init__(self) -> None:
-        self.event: Optional[Event] = None
+        self.event: Optional[EventType] = None
         
     def init(self) -> None:
         self.event = Event()

--- a/mpire/dashboard/dashboard.py
+++ b/mpire/dashboard/dashboard.py
@@ -9,7 +9,6 @@ import logging
 import os
 import signal
 import socket
-import sys
 from datetime import datetime
 from multiprocessing import Event, Process
 from multiprocessing.managers import BaseProxy
@@ -45,7 +44,13 @@ def index() -> str:
 
     :return: HTML
     """
-    return render_template('index.html', username=getpass.getuser(), hostname=socket.gethostname(),
+    # Obtain user. This can fail when the current uid refers to a non-existing user, which can happen when running in a
+    # container as a non-root user. See https://github.com/sybrenjansen/mpire/issues/128.
+    try:
+        user = getpass.getuser()
+    except KeyError:
+        user = "n/a"
+    return render_template('index.html', username=user, hostname=socket.gethostname(),
                            manager_host=DASHBOARD_MANAGER_CONNECTION_DETAILS.host or 'localhost',
                            manager_port_nr=DASHBOARD_MANAGER_CONNECTION_DETAILS.port)
 

--- a/mpire/dashboard/utils.py
+++ b/mpire/dashboard/utils.py
@@ -128,8 +128,15 @@ def get_function_details(func: Callable) -> Dict[str, Union[str, int]]:
         function_line_no = 'n/a'
         function_name = 'n/a'
 
+    # Obtain user. This can fail when the current uid refers to a non-existing user, which can happen when running in a
+    # container as a non-root user. See https://github.com/sybrenjansen/mpire/issues/128.
+    try:
+        user = getpass.getuser()
+    except KeyError:
+        user = "n/a"
+        
     # Populate details
-    func_details = {'user': f'{getpass.getuser()}@{socket.gethostname()}',
+    func_details = {'user': f'{user}@{socket.gethostname()}',
                     'function_filename': function_filename,
                     'function_line_no': function_line_no,
                     'function_name': function_name,

--- a/mpire/progress_bar.py
+++ b/mpire/progress_bar.py
@@ -52,7 +52,7 @@ class ProgressBarHandler:
         self.progress_bar_style = progress_bar_style
         self.worker_comms = worker_comms
         self.worker_insights = worker_insights
-        if show_progress_bar and DASHBOARD_STARTED_EVENT is not None:
+        if show_progress_bar and DASHBOARD_STARTED_EVENT is not None and DASHBOARD_STARTED_EVENT.is_set():
             self.function_details = get_function_details(map_params.func)
             self.function_details['n_jobs'] = pool_params.n_jobs
         else:
@@ -186,7 +186,6 @@ class ProgressBarHandler:
         :param progress_bar: tqdm progress bar instance
         """
         if self.progress_bar_id is None and DASHBOARD_STARTED_EVENT is not None and DASHBOARD_STARTED_EVENT.is_set():
-
             # Connect to manager server
             self.dashboard_dict, self.dashboard_details_dict, dashboard_tqdm_lock = get_manager_client_dicts()
 


### PR DESCRIPTION
* Function details in ``progress_bar.py`` are only obtained when the dashboard is running
* Obtaining the user name is now put in a try-except block to prevent MPIRE from crashing when the user name cannot be obtained. which can happen when running in a container as a non-root user

Fixes #128 