### PR TITLE
#130 error messages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Expanded error message in case of unexpected worker death (`#130`_)
+* The progress bar will now show ``Keyboard interrupt`` when a keyboard interrupt is raised to distinguish it from 
+  other exceptions
+
+.. _#130: https://github.com/sybrenjansen/mpire/issues/130
+
 2.10.2
 ------
 

--- a/mpire/pool.py
+++ b/mpire/pool.py
@@ -307,7 +307,10 @@ class WorkerPool:
                     # Obtain task it was working on and set it to failed
                     job_id = self._worker_comms.get_worker_working_on_job(worker_id)
                     self._worker_comms.signal_exception_thrown(job_id)
-                    err = RuntimeError(f"Worker-{worker_id} died unexpectedly")
+                    err = RuntimeError(
+                        f"Worker-{worker_id} died unexpectedly. This usually means the OS/kernel killed the process "
+                        "due to running out of memory"
+                    )
 
                     # When a worker dies unexpectedly, the pool shuts down and we set all tasks that haven't completed
                     # yet to failed

--- a/mpire/progress_bar.py
+++ b/mpire/progress_bar.py
@@ -7,7 +7,7 @@ import warnings
 
 from tqdm import TqdmExperimentalWarning, tqdm as tqdm_type
 
-from mpire.comms import WorkerComms, POISON_PILL
+from mpire.comms import MAIN_PROCESS, POISON_PILL, WorkerComms
 from mpire.exception import remove_highlighting
 from mpire.insights import WorkerInsights
 from mpire.params import WorkerMapParams, WorkerPoolParams
@@ -141,7 +141,12 @@ class ProgressBarHandler:
                 # Check if we got a poison pill because there was an error. If so, we obtain the exception information
                 # and send it to the dashboard, if available.)
                 if self.worker_comms.exception_thrown() or self.worker_comms.kill_signal_received():
-                    progress_bar.set_description('Exception occurred, terminating ... ')
+                    error_str = (
+                        "Keyboard interrupt" 
+                        if self.worker_comms.get_exception_thrown_job_id() == MAIN_PROCESS else 
+                        "Exception occurred"
+                    )
+                    progress_bar.set_description(f"{error_str}, terminating workers")
                     if self.worker_comms.exception_thrown():
                         # Wait for exception traceback str to be set
                         with self.exception_traceback_str_set_condition:


### PR DESCRIPTION
* Expanded error message in case of unexpected worker death (#130)
* The progress bar will now show ``Keyboard interrupt`` when a keyboard interrupt is raised to distinguish it from other exceptions