### PR TITLE
Add option to change refresh-interval

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,9 +10,11 @@ Unreleased
 * In the case of an unexpected worker death (e.g., OOM errors) and the worker was working on an ``apply`` task, the 
   worker will now be restarted and the other workers will continue their work. The task that caused the death will be 
   set to failed (`#110`_)
+* Add option on dashboard to change the refresh interval (`#136`_)
 
 .. _#110: https://github.com/sybrenjansen/mpire/issues/110
 .. _#130: https://github.com/sybrenjansen/mpire/issues/130
+.. _#136: https://github.com/sybrenjansen/mpire/pull/136
 
 2.10.2
 ------

--- a/mpire/dashboard/static/refresh.js
+++ b/mpire/dashboard/static/refresh.js
@@ -14,9 +14,8 @@ $(function() {
 var progress_bar_animation_duration = 450;
 var refresh_interval = 500;
 var completed_pb_ids = {};
+var interval_id = setInterval(refresh, refresh_interval);
 refresh();
-setInterval(refresh, refresh_interval);
-
 
 // Update progress bar given an ID and a progress (between 0-1)
 function update_progress_bar(pb_id, progress)
@@ -122,6 +121,15 @@ function AddReadMore(tag_id, char_limit, text)
 // Refresh contents
 function refresh()
 {
+    var new_refresh_interval = Math.max(100, parseInt($('#refresh_interval').val()));
+    if (! isNaN(new_refresh_interval) && new_refresh_interval != refresh_interval)
+    {
+        refresh_interval = new_refresh_interval;
+        clearInterval(interval_id);
+        interval_id = setInterval(refresh, refresh_interval);
+        $('#refresh_interval').val(refresh_interval);
+    }
+
     $.getJSON($SCRIPT_ROOT + '/_progress_bar_update', {}, function(data)
     {
         var i, worker_id, worker_prefix, task_idx, task_prefix;

--- a/mpire/dashboard/static/refresh.js
+++ b/mpire/dashboard/static/refresh.js
@@ -13,9 +13,10 @@ $(function() {
 
 var progress_bar_animation_duration = 450;
 var refresh_interval = 500;
+var last_refresh = 1;
 var completed_pb_ids = {};
 var interval_id = setInterval(refresh, refresh_interval);
-refresh();
+
 
 // Update progress bar given an ID and a progress (between 0-1)
 function update_progress_bar(pb_id, progress)
@@ -130,9 +131,13 @@ function refresh()
         $('#refresh_interval').val(refresh_interval);
     }
 
-    $.getJSON($SCRIPT_ROOT + '/_progress_bar_update', {}, function(data)
+    $.getJSON($SCRIPT_ROOT + '/_progress_bar_update', {"since": last_refresh}, function(data)
     {
         var i, worker_id, worker_prefix, task_idx, task_prefix;
+        if (data.time !== undefined)
+        {
+            last_refresh = data.time;
+        }
         for (i = 0; i < data.result.length; i++)
         {
             var pb = data.result[i];

--- a/mpire/dashboard/templates/menu_top_right.html
+++ b/mpire/dashboard/templates/menu_top_right.html
@@ -1,5 +1,9 @@
 <div id="menu-top-right">
 
+
+    <label>
+        Refresh interval: <input type="number" id="refresh_interval" value="500" min="100" step="100" size="5"/>ms
+    </label>
     <a href="https://slimmer-ai.github.io/mpire/" target="_blank">
         <button class="btn btn-secondary">Docs</button>
     </a>


### PR DESCRIPTION
If you use a long-running dashboard, and especially if you have a few stack-traces, the bandwidth consumption can get pretty high, so it would be nice to be able to reduce the refresh rate.

Other options to tackle the issue would be to only request updates for progress-bars that haven't completed/stopped, and perhaps using websockets.